### PR TITLE
correct HTML copy path

### DIFF
--- a/perf/scripts/gen_website.sh
+++ b/perf/scripts/gen_website.sh
@@ -5,9 +5,9 @@ rm -rf tmp && mkdir tmp
 cd tmp && git clone https://github.com/open-quantum-safe/profiling.git && cd ..
 rm -rf out && mkdir out
 python3 gen_website.py 2020-10-04 ${1} out
-cp tmp/speed/visualization/*.html out
-cp tmp/speed/visualization/*.js out
-cp tmp/speed/visualization/*.css out
+cp tmp/profiling/visualization/*.html out
+cp tmp/profiling/visualization/*.js out
+cp tmp/profiling/visualization/*.css out
 cd out && tar czvf ../site.tgz * && cd ..
 cp site.tgz ${1}/site
 rm -rf tmp out


### PR DESCRIPTION
:-(Omitted) Path copy added that's required for correct generation of HTML tarball. Will merge later today to resurrect profiling website.