### PR TITLE
Switch to Debian; multiarch build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
 #            #chmod u+x get-docker.sh && /root/get-docker.sh
 #          workdir:
 #            /root
+# enable docker if not in machine:
+      - setup_remote_docker
       - run:
           name: Check versions
           command: |
@@ -43,8 +45,6 @@ jobs:
           command: |
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && 
             docker run -it arm64v8/debian:buster-slim uname -a
-# enable if not in machine:
-      - setup_remote_docker
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run: uname -a
 # enable for CCI pushing:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
             # The CircleCI executor offers 35 cores, but using
             # all of them might exhaust memory
             # explicitly tag platform
+            export DOCKER_CLI_EXPERIMENTAL=enabled
             docker build --platform arm64 --build-arg MAKE_DEFINES="-j 18" -t oqs-mperf-arm64 -f Dockerfile-arm64 . &&
             docker run -it oqs-mperf-arm64 /opt/test/selftest.sh
           working_directory: perf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
             # all of them might exhaust memory
             # explicitly tag platform
             export DOCKER_CLI_EXPERIMENTAL=enabled
+            docker version
             docker build --platform arm64 --build-arg MAKE_DEFINES="-j 18" -t oqs-mperf-arm64 -f Dockerfile-arm64 . &&
             docker run -it oqs-mperf-arm64 /opt/test/selftest.sh
           working_directory: perf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,10 +120,12 @@ jobs:
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
-                name: Merge and push manifests to create multiarch image
+                name: Merge and push manifests to properly label multiarch image
                 command: |
                    export DOCKER_CLI_EXPERIMENTAL=enabled
-                   docker manifest create $TARGETNAME/oqs-mperf:latest --amend $TARGETNAME/oqs-mperf:latest-amd64 --amend $TARGETNAME/oqs-mperf:latest-arm64
+                   docker manifest create $TARGETNAME/oqs-mperf:latest $TARGETNAME/oqs-mperf:latest-amd64 $TARGETNAME/oqs-mperf:latest-arm64
+                   # if --platform is not properly honored in build, set it explicitly here
+                   docker manifest annotate $TARGETNAME/oqs-mperf:latest $TARGETNAME/oqs-mperf:latest-arm64 --arch arm64
                    docker push $TARGETNAME/oqs-mperf:latest
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,23 +18,9 @@ localCheckout: &localCheckout
 jobs:
   debian_arm64:
     description: Building and pushing ARM64 benchmarking baselin image 
-# to be used at CCI if docker doesn't work:
-#    machine:
-#      image: ubuntu-2004:202101-01
     docker:
-#      #- image: debian:stable-slim
       - image: openquantumsafe/ci-debian-buster-amd64
     steps:
-#      - run:
-#          name: Setup docker and qemu
-#          command: |
-#            dpkg --add-architecture arm64 && apt -y update && apt -y upgrade && apt -y install qemu-user-static binfmt-support curl docker.io gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static libssl-dev:arm64
-#            # manually get docker if install fails
-#            #curl -fsSL https://get.docker.com -o get-docker.sh
-#            #chmod u+x get-docker.sh && /root/get-docker.sh
-#          workdir:
-#            /root
-# enable docker if not in machine:
       - setup_remote_docker
       - run:
           name: Check versions
@@ -46,8 +32,6 @@ jobs:
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && 
             docker run -it arm64v8/debian:buster-slim uname -a
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
-      - run: uname -a
-# enable for CCI pushing:
       - run:
           name: Authenticate to Docker
           command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
@@ -56,8 +40,8 @@ jobs:
           command: |
             # The CircleCI executor offers 35 cores, but using
             # all of them might exhaust memory
-            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-perf-arm64 -f Dockerfile-arm64 . &&
-            docker run -it oqs-perf-arm64 /opt/test/selftest.sh
+            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-mperf-arm64 -f Dockerfile-arm64 . &&
+            docker run -it oqs-mperf-arm64 /opt/test/selftest.sh
           working_directory: perf
       - when:
           condition:
@@ -70,8 +54,8 @@ jobs:
             - run:
                 name: Push all images
                 command: |
-                  docker tag oqs-multiperf $TARGETNAME/oqs-multiperf &&
-                  docker push $TARGETNAME/oqs-multiperf
+                  docker tag oqs-mperf-arm64 $TARGETNAME/oqs-mperf:latest-arm64 &&
+                  docker push $TARGETNAME/oqs-mperf:latest-arm64
 
   debian_x64:
     description: A template for building and pushing OQS performance testing Docker image on Ubuntu Bionic that depend on OQS-OpenSSL
@@ -91,20 +75,45 @@ jobs:
           command: |
             # The CircleCI executor offers 35 cores, but using
             # all of them might exhaust memory
-            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-perf . &&
-            docker run -it oqs-perf /opt/test/selftest.sh
+            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-mperf . &&
+            docker run -it oqs-mperf /opt/test/selftest.sh
           working_directory: perf
       - when:
           condition:
             or:
+              - equal: [ mb-debian, << pipeline.git.branch >> ]
               - equal: [ main, << pipeline.git.branch >> ]
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
                 name: Push all images
                 command: |
-                  docker tag oqs-perf $TARGETNAME/oqs-perf:latest &&
-                  docker push $TARGETNAME/oqs-perf:latest 
+                  docker tag oqs-mperf $TARGETNAME/oqs-mperf:latest-amd64 &&
+                  docker push $TARGETNAME/oqs-mperf:latest-amd64 
+  merge:
+    description: merging multiple architecture docker images into one multiarch image
+    docker:
+      - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
+        auth:
+          username: $DOCKER_LOGIN
+          password: $DOCKER_PASSWORD
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Authenticate to Docker
+          command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+      - when:
+          condition:
+            or:
+              - equal: [ mb-debian, << pipeline.git.branch >> ]
+              - equal: [ main, << pipeline.git.branch >> ]
+              - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
+          steps:
+            - run:
+                name: Merge
+                command: |
+                   export DOCKER_CLI_EXPERIMENTAL=enabled
+                   docker manifest create $TARGETNAME/oqs-mperf:latest --amend $TARGETNAME/oqs-mperf:latest-amd64 --amend $TARGETNAME/oqs-mperf:latest-arm64
 
 workflows:
   version: 2.1
@@ -113,4 +122,9 @@ workflows:
       - debian_x64:
           context: openquantumsafe
       - debian_arm64:
+          context: openquantumsafe
+      - merge:
+          requires:
+             - debian_x64
+             - debian_arm64
           context: openquantumsafe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,13 @@ jobs:
           command: |
             qemu-aarch64-static --version
       - run:
+          name: Enable experimental features on docker server
+          command: |
+            ssh remote-docker \<<EOF
+              sudo bash -c 'echo "{\"experimental\": true}" > /etc/docker/daemon.json'
+              sudo systemctl restart docker
+            EOF
+      - run:
           name: activate multiarch
           command: |
             docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,62 @@ localCheckout: &localCheckout
     cp -a /tmp/_circleci_local_build_repo/.git ${PROJECT_PATH}
 
 jobs:
-  ubuntu_x64_openssl:
+  debian_arm64:
+    description: Building and pushing ARM64 benchmarking baselin image 
+# to be used at CCI
+    machine:
+      image: ubuntu-2004:202101-01
+# for local testing:
+#    docker:
+#      #- image: debian:stable-slim
+#      - image: openquantumsafe/ci-debian-buster-amd64
+    steps:
+      - run:
+          name: Setup docker and qemu
+          command: |
+            sudo dpkg --add-architecture arm64 && apt -y update && apt -y upgrade && apt -y install qemu-user-static binfmt-support curl docker.io gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static libssl-dev:arm64
+            # manually get docker if install fails
+            #curl -fsSL https://get.docker.com -o get-docker.sh
+            #chmod u+x get-docker.sh && /root/get-docker.sh
+          workdir:
+            /root
+      - run:
+          name: Check versions
+          command: |
+            qemu-aarch64-static --version
+            update-binfmts --version 
+# enable for local testing
+      - setup_remote_docker
+      - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
+      - run: uname -a
+# enable for CCI pushing:
+      - run:
+          name: Authenticate to Docker
+          command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+      - run:
+          name: Build and test profiling image
+          command: |
+            # The CircleCI executor offers 35 cores, but using
+            # all of them might exhaust memory
+            #docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-perf-arm64 -f Dockerfile-arm64 . &&
+            docker build --build-arg MAKE_DEFINES="-j 2" -t oqs-perf-arm64 -f Dockerfile-arm64 . &&
+            docker run -it oqs-perf-arm64 /opt/test/selftest.sh
+          working_directory: perf
+      - when:
+          condition:
+            or:
+              # just to test:
+              - equal: [ mb-debian, << pipeline.git.branch >> ]
+              - equal: [ main, << pipeline.git.branch >> ]
+              - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
+          steps:
+            - run:
+                name: Push all images
+                command: |
+                  docker tag oqs-multiperf $TARGETNAME/oqs-multiperf &&
+                  docker push $TARGETNAME/oqs-multiperf
+
+  debian_x64:
     description: A template for building and pushing OQS performance testing Docker image on Ubuntu Bionic that depend on OQS-OpenSSL
     docker:
       - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
@@ -53,5 +108,7 @@ workflows:
   version: 2.1
   build:
     jobs:
-      - ubuntu_x64_openssl:
+      - debian_x64:
+          context: openquantumsafe
+      - debian_arm64:
           context: openquantumsafe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,30 +18,29 @@ localCheckout: &localCheckout
 jobs:
   debian_arm64:
     description: Building and pushing ARM64 benchmarking baselin image 
-# to be used at CCI
-    machine:
-      image: ubuntu-2004:202101-01
-# for local testing:
-#    docker:
+# to be used at CCI if docker doesn't work:
+#    machine:
+#      image: ubuntu-2004:202101-01
+    docker:
 #      #- image: debian:stable-slim
-#      - image: openquantumsafe/ci-debian-buster-amd64
+      - image: openquantumsafe/ci-debian-buster-amd64
     steps:
-      - run:
-          name: Setup docker and qemu
-          command: |
-            sudo dpkg --add-architecture arm64 && apt -y update && apt -y upgrade && apt -y install qemu-user-static binfmt-support curl docker.io gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static libssl-dev:arm64
-            # manually get docker if install fails
-            #curl -fsSL https://get.docker.com -o get-docker.sh
-            #chmod u+x get-docker.sh && /root/get-docker.sh
-          workdir:
-            /root
+#      - run:
+#          name: Setup docker and qemu
+#          command: |
+#            dpkg --add-architecture arm64 && apt -y update && apt -y upgrade && apt -y install qemu-user-static binfmt-support curl docker.io gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static libssl-dev:arm64
+#            # manually get docker if install fails
+#            #curl -fsSL https://get.docker.com -o get-docker.sh
+#            #chmod u+x get-docker.sh && /root/get-docker.sh
+#          workdir:
+#            /root
       - run:
           name: Check versions
           command: |
             qemu-aarch64-static --version
             update-binfmts --version 
-# enable for local testing
-#      - setup_remote_docker
+# enable if not in machine:
+      - setup_remote_docker
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run: uname -a
 # enable for CCI pushing:
@@ -53,8 +52,7 @@ jobs:
           command: |
             # The CircleCI executor offers 35 cores, but using
             # all of them might exhaust memory
-            #docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-perf-arm64 -f Dockerfile-arm64 . &&
-            docker build --build-arg MAKE_DEFINES="-j 2" -t oqs-perf-arm64 -f Dockerfile-arm64 . &&
+            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-perf-arm64 -f Dockerfile-arm64 . &&
             docker run -it oqs-perf-arm64 /opt/test/selftest.sh
           working_directory: perf
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             qemu-aarch64-static --version
             update-binfmts --version 
 # enable for local testing
-      - setup_remote_docker
+#      - setup_remote_docker
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run: uname -a
 # enable for CCI pushing:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,11 @@ jobs:
           name: Check versions
           command: |
             qemu-aarch64-static --version
-            update-binfmts --version 
+      - run:
+          name: activate multiarch
+          command: |
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && 
+            docker run -it arm64v8/debian:buster-slim uname -a
 # enable if not in machine:
       - setup_remote_docker
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,16 +56,14 @@ jobs:
       - when:
           condition:
             or:
-              # just to test:
-              - equal: [ mb-debian, << pipeline.git.branch >> ]
               - equal: [ main, << pipeline.git.branch >> ]
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
                 name: Push image
                 command: |
-                  docker tag oqs-mperf-arm64 $TARGETNAME/oqs-mperf:latest-arm64 &&
-                  docker push $TARGETNAME/oqs-mperf:latest-arm64
+                  docker tag oqs-mperf-arm64 $TARGETNAME/oqs-perf:latest-arm64 &&
+                  docker push $TARGETNAME/oqs-perf:latest-arm64
 
   debian_x64:
     description: A template for building and pushing OQS performance testing Docker image on Ubuntu Bionic that depend on OQS-OpenSSL
@@ -91,15 +89,14 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ mb-debian, << pipeline.git.branch >> ]
               - equal: [ main, << pipeline.git.branch >> ]
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
                 name: Push image
                 command: |
-                  docker tag oqs-mperf $TARGETNAME/oqs-mperf:latest-amd64 &&
-                  docker push $TARGETNAME/oqs-mperf:latest-amd64 
+                  docker tag oqs-mperf $TARGETNAME/oqs-perf:latest-amd64 &&
+                  docker push $TARGETNAME/oqs-perf:latest-amd64 
   merge:
     description: merging multiple architecture docker images into one multiarch image
     docker:
@@ -115,7 +112,6 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ mb-debian, << pipeline.git.branch >> ]
               - equal: [ main, << pipeline.git.branch >> ]
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
@@ -123,10 +119,10 @@ jobs:
                 name: Merge and push manifests to properly label multiarch image
                 command: |
                    export DOCKER_CLI_EXPERIMENTAL=enabled
-                   docker manifest create $TARGETNAME/oqs-mperf:latest $TARGETNAME/oqs-mperf:latest-amd64 $TARGETNAME/oqs-mperf:latest-arm64
+                   docker manifest create $TARGETNAME/oqs-perf:latest $TARGETNAME/oqs-perf:latest-amd64 $TARGETNAME/oqs-perf:latest-arm64
                    # if --platform is not properly honored in build, set it explicitly here
-                   docker manifest annotate $TARGETNAME/oqs-mperf:latest $TARGETNAME/oqs-mperf:latest-arm64 --arch arm64
-                   docker manifest push $TARGETNAME/oqs-mperf:latest
+                   docker manifest annotate $TARGETNAME/oqs-perf:latest $TARGETNAME/oqs-perf:latest-arm64 --arch arm64
+                   docker manifest push $TARGETNAME/oqs-perf:latest
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
-                name: Push all images
+                name: Push image
                 command: |
                   docker tag oqs-mperf-arm64 $TARGETNAME/oqs-mperf:latest-arm64 &&
                   docker push $TARGETNAME/oqs-mperf:latest-arm64
@@ -96,7 +96,7 @@ jobs:
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
-                name: Push all images
+                name: Push image
                 command: |
                   docker tag oqs-mperf $TARGETNAME/oqs-mperf:latest-amd64 &&
                   docker push $TARGETNAME/oqs-mperf:latest-amd64 
@@ -126,7 +126,7 @@ jobs:
                    docker manifest create $TARGETNAME/oqs-mperf:latest $TARGETNAME/oqs-mperf:latest-amd64 $TARGETNAME/oqs-mperf:latest-arm64
                    # if --platform is not properly honored in build, set it explicitly here
                    docker manifest annotate $TARGETNAME/oqs-mperf:latest $TARGETNAME/oqs-mperf:latest-arm64 --arch arm64
-                   docker push $TARGETNAME/oqs-mperf:latest
+                   docker manifest push $TARGETNAME/oqs-mperf:latest
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ jobs:
           command: |
             # The CircleCI executor offers 35 cores, but using
             # all of them might exhaust memory
-            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-mperf-arm64 -f Dockerfile-arm64 . &&
+            # explicitly tag platform
+            docker build --platform arm64 --build-arg MAKE_DEFINES="-j 18" -t oqs-mperf-arm64 -f Dockerfile-arm64 . &&
             docker run -it oqs-mperf-arm64 /opt/test/selftest.sh
           working_directory: perf
       - when:
@@ -110,10 +111,11 @@ jobs:
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:
-                name: Merge
+                name: Merge and push manifests to create multiarch image
                 command: |
                    export DOCKER_CLI_EXPERIMENTAL=enabled
                    docker manifest create $TARGETNAME/oqs-mperf:latest --amend $TARGETNAME/oqs-mperf:latest-amd64 --amend $TARGETNAME/oqs-mperf:latest-arm64
+                   docker push $TARGETNAME/oqs-mperf:latest
 
 workflows:
   version: 2.1

--- a/perf/Dockerfile
+++ b/perf/Dockerfile
@@ -1,8 +1,5 @@
 # Multi-stage build: First the full builder image:
 
-# define the Curl version to be baked in
-ARG CURL_VERSION=7.73.0
-
 # define the S3FS version to be baked in
 ARG S3FS_VERSION=1.82
 
@@ -10,7 +7,7 @@ ARG S3FS_VERSION=1.82
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-ARG LIBOQS_BUILD_DEFINES=
+ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
 
 # openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
 ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768:newhope1024cca"
@@ -21,56 +18,67 @@ ARG SIG_ALG="dilithium2"
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"
 
+# Define main performance architecture(s)
+ARG PERF_ARCH_X64="skylake-avx512"
 
-FROM alpine:3.11 as intermediate
+# default architecture
+ARG ARCH="amd64"
+
+FROM multiarch/debian-debootstrap:${ARCH}-buster as intermediate
 # Take in all global args
-ARG CURL_VERSION
-ARG S3FS_VERSION
 ARG INSTALLDIR
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_BUILD_DEFINES
 ARG SIG_ALG
+ARG PERF_ARCH_X64
 ARG MAKE_DEFINES
 
 LABEL version="2"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apk update && apk upgrade
-
 # Get all software packages required for builing all components:
-RUN apk add build-base linux-headers \
-            libtool automake autoconf cmake \
-            make \
-            openssl openssl-dev \
-            git docker wget fuse fuse-dev curl-dev libxml2-dev
+RUN dpkg --add-architecture arm64 && \
+    apt-get update -qq && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y gcc \
+       cmake ninja-build \
+       autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev \
+       doxygen  \
+       python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io \
+       python3-psutil \
+       maven openjdk-11-jdk \
+       gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static \
+       docker \
+       libssl-dev:arm64 s3fs
+
 
 # get all sources
 WORKDIR /opt
 RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
     git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src && \
-    wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz && tar -zxvf curl-${CURL_VERSION}.tar.gz && \
-    wget https://github.com/s3fs-fuse/s3fs-fuse/archive/v${S3FS_VERSION}.tar.gz && tar -xzvf v${S3FS_VERSION}.tar.gz
+    cp -R /opt/ossl-src /opt/ossl-src-arm64
 
-# build s3fs:
-WORKDIR /opt/s3fs-fuse-${S3FS_VERSION}
-RUN ./autogen.sh && ./configure --prefix=/usr && make ${MAKE_DEFINES} && make install
-
-RUN s3fs --version
+RUN s3fs --version 
 
 # build liboqs shared and static, distributable
 WORKDIR /opt/liboqs
+# base platform build (x86_64)
 RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 RUN mkdir build-static && cd build-static && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 
+# cross build build (arm64)
+RUN mkdir build-arm-shared && cd build-arm-shared && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src-arm64/oqs && make ${MAKE_DEFINES} && make install
+RUN mkdir build-arm-static && cd build-arm-static && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src-arm64/oqs && make ${MAKE_DEFINES} && make install
+
 # build OQS-OpenSSL
 WORKDIR /opt/ossl-src
-# curl looks for shared libraries
 # at ./configure time
 RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
-    make ${MAKE_DEFINES} && make install;
+    make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
 
-# set path to use 'new' openssl & curl. Dyn libs have been properly linked in to match
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
 
 # generate certificates for openssl s_server, which is what we will test curl against
@@ -82,30 +90,14 @@ WORKDIR ${INSTALLDIR}/bin
 RUN set -x && \
     ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} 
 
-# build curl - injecting OQS CA generated above into root store
-WORKDIR /opt/curl-${CURL_VERSION}
-
-# Download and integrate LetsEncrypt Root CA to CA bundle
-RUN wget https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt && cat ${INSTALLDIR}/bin/CA.crt >> letsencryptauthorityx3.pem.txt 
-
-# For curl debugging enable it by adding the line below to the configure command:
-#                    --enable-debug \
-
-RUN env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
-        LDFLAGS=-Wl,-R${INSTALLDIR}/lib  \
-        ./configure --prefix=${INSTALLDIR} \
-                    --with-ca-bundle=${INSTALLDIR}/oqs-bundle.pem \
-                    --with-ssl=${INSTALLDIR} && \
-    make ${MAKE_DEFINES} && make install && mv letsencryptauthorityx3.pem.txt ${INSTALLDIR}/oqs-bundle.pem;
-
 WORKDIR /opt/liboqs
 # Build ref-only variants and store in INSTALLDIR-ref
 RUN mkdir build-shared-ref && cd build-shared-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
 RUN mkdir build-static-ref && cd build-static-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
 
 # Build noportable fast variants and store in INSTALLDIR-noport (liboqs build default)
-RUN mkdir build-shared-noport && cd build-shared-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="skylake-avx512" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
-RUN mkdir build-static-noport && cd build-static-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="skylake-avx512" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
+RUN mkdir build-shared-noport && cd build-shared-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-noport && cd build-static-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
 
 # Download current test.openquantumsafe.org test CA cert
 WORKDIR ${INSTALLDIR}
@@ -114,16 +106,21 @@ RUN wget https://test.openquantumsafe.org/CA.crt && mv CA.crt oqs-testca.pem
 WORKDIR /
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:3.11 as dev
+ARG ARCH
+FROM multiarch/debian-debootstrap:${ARCH}-buster as dev
 # Take in all global args
 ARG INSTALLDIR
 ARG SIG_ALG
 
 # Dependencies for logfile analysis and S3FS:
-RUN apk add python3 fuse libxml2 curl libstdc++6 git valgrind perl && ln -s /usr/lib/gcc/`(uname -m)`-alpine-linux-musl/6.4.0/libstdc\+\+.so.6 /usr/lib/libstdc\+\+.so.6 && rm -rf /var/cache/apk/*;
+# Get all software packages required for builing all components:
+RUN dpkg --add-architecture arm64 && \
+    apt-get update -qq && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y python3 fuse valgrind libssl-dev:arm64 s3fs && \
+    apt autoremove && rm -rf /var/cache/apt/*
 
-# Move s3fs over...
-COPY --from=intermediate /usr/bin/s3fs /usr/bin/s3fs
 # Retain the ${INSTALLDIR} contents in the final image
 COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}
 # Also retain liboqs speed-executables
@@ -141,7 +138,7 @@ COPY --from=intermediate /opt/liboqs/build-static-ref/tests/test_sig_mem ${INSTA
 COPY --from=intermediate /opt/liboqs/build-static-noport/tests/test_kem_mem ${INSTALLDIR}/bin/test_kem_mem-noport
 COPY --from=intermediate /opt/liboqs/build-static-noport/tests/test_sig_mem ${INSTALLDIR}/bin/test_sig_mem-noport
 
-# set path to use 'new' openssl & curl. Dyn libs have been properly linked in to match
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
 
 # config locations
@@ -161,7 +158,7 @@ FROM dev
 ARG INSTALLDIR
 
 # Enable a normal user to create new server keys off set CA
-RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs /opt/test 
+RUN addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test 
 
 # permit changes to liboqs lib by normal oqs user:
 RUN chmod gou+rwx /opt/oqssa/lib

--- a/perf/Dockerfile
+++ b/perf/Dockerfile
@@ -1,13 +1,11 @@
 # Multi-stage build: First the full builder image:
 
-# define the S3FS version to be baked in
-ARG S3FS_VERSION=1.82
-
 # Default location where all binaries wind up:
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
 ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
+#ARG LIBOQS_BUILD_DEFINES=""
 
 # openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
 ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768:newhope1024cca"
@@ -57,22 +55,15 @@ RUN dpkg --add-architecture arm64 && \
 # get all sources
 WORKDIR /opt
 RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
-    git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src && \
-    cp -R /opt/ossl-src /opt/ossl-src-arm64
+    git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src
 
-RUN s3fs --version 
-
-# build liboqs shared and static, distributable
+# build liboqs shared and static, distributable (x86_64)
 WORKDIR /opt/liboqs
 # base platform build (x86_64)
 RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 RUN mkdir build-static && cd build-static && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 
-# cross build build (arm64)
-RUN mkdir build-arm-shared && cd build-arm-shared && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src-arm64/oqs && make ${MAKE_DEFINES} && make install
-RUN mkdir build-arm-static && cd build-arm-static && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src-arm64/oqs && make ${MAKE_DEFINES} && make install
-
-# build OQS-OpenSSL
+# build OQS-OpenSSL (x86_64)
 WORKDIR /opt/ossl-src
 # at ./configure time
 RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
@@ -91,11 +82,11 @@ RUN set -x && \
     ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} 
 
 WORKDIR /opt/liboqs
-# Build ref-only variants and store in INSTALLDIR-ref
+# Build ref-only variants and store in INSTALLDIR-ref (x86_64)
 RUN mkdir build-shared-ref && cd build-shared-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
 RUN mkdir build-static-ref && cd build-static-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
 
-# Build noportable fast variants and store in INSTALLDIR-noport (liboqs build default)
+# Build noportable fast variants and store in INSTALLDIR-noport (liboqs build default) (x86_64)
 RUN mkdir build-shared-noport && cd build-shared-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
 RUN mkdir build-static-noport && cd build-static-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
 
@@ -107,18 +98,16 @@ WORKDIR /
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
 ARG ARCH
-FROM multiarch/debian-debootstrap:${ARCH}-buster as dev
+FROM debian:buster-slim as dev
 # Take in all global args
 ARG INSTALLDIR
 ARG SIG_ALG
 
 # Dependencies for logfile analysis and S3FS:
 # Get all software packages required for builing all components:
-RUN dpkg --add-architecture arm64 && \
-    apt-get update -qq && \
-    apt-get upgrade -y && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y python3 fuse valgrind libssl-dev:arm64 s3fs && \
+RUN apt update && apt upgrade -y && \
+    apt dist-upgrade -y && \
+    apt install -y python3 fuse valgrind libssl-dev s3fs && \
     apt autoremove && rm -rf /var/cache/apt/*
 
 # Retain the ${INSTALLDIR} contents in the final image
@@ -163,8 +152,7 @@ RUN addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 -
 # permit changes to liboqs lib by normal oqs user:
 RUN chmod gou+rwx /opt/oqssa/lib
 RUN chmod gou+rwx /opt/oqssa/lib/*
-
-USER oqs
+#USER oqs
 WORKDIR /opt/test
 CMD ["/opt/test/run-tests.sh"]
-STOPSIGNAL SIGTERM
+#STOPSIGNAL SIGTERM

--- a/perf/Dockerfile
+++ b/perf/Dockerfile
@@ -4,8 +4,9 @@
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
-#ARG LIBOQS_BUILD_DEFINES=""
+#for minimal build:
+#ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
+ARG LIBOQS_BUILD_DEFINES=""
 
 # openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
 ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768:newhope1024cca"

--- a/perf/Dockerfile
+++ b/perf/Dockerfile
@@ -4,7 +4,7 @@
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-#for minimal build:
+# for minimal build:
 #ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
 ARG LIBOQS_BUILD_DEFINES=""
 
@@ -64,9 +64,16 @@ WORKDIR /opt/liboqs
 RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 RUN mkdir build-static && cd build-static && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 
+# Build ref-only variants and store in INSTALLDIR-ref (x86_64)
+RUN mkdir build-shared-ref && cd build-shared-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-ref && cd build-static-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
+
+# Build noportable fast variants and store in INSTALLDIR-noport (liboqs build default) (x86_64)
+RUN mkdir build-shared-noport && cd build-shared-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-noport && cd build-static-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
+
 # build OQS-OpenSSL (x86_64)
 WORKDIR /opt/ossl-src
-# at ./configure time
 RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
     make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
 
@@ -81,19 +88,6 @@ WORKDIR ${INSTALLDIR}/bin
 # generate CA key and cert
 RUN set -x && \
     ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} 
-
-WORKDIR /opt/liboqs
-# Build ref-only variants and store in INSTALLDIR-ref (x86_64)
-RUN mkdir build-shared-ref && cd build-shared-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
-RUN mkdir build-static-ref && cd build-static-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
-
-# Build noportable fast variants and store in INSTALLDIR-noport (liboqs build default) (x86_64)
-RUN mkdir build-shared-noport && cd build-shared-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
-RUN mkdir build-static-noport && cd build-static-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install
-
-# Download current test.openquantumsafe.org test CA cert
-WORKDIR ${INSTALLDIR}
-RUN wget https://test.openquantumsafe.org/CA.crt && mv CA.crt oqs-testca.pem
 
 WORKDIR /
 
@@ -128,6 +122,8 @@ COPY --from=intermediate /opt/liboqs/build-static-ref/tests/test_sig_mem ${INSTA
 COPY --from=intermediate /opt/liboqs/build-static-noport/tests/test_kem_mem ${INSTALLDIR}/bin/test_kem_mem-noport
 COPY --from=intermediate /opt/liboqs/build-static-noport/tests/test_sig_mem ${INSTALLDIR}/bin/test_sig_mem-noport
 
+COPY scripts/* /opt/test/
+
 # set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
 
@@ -135,25 +131,18 @@ ENV PATH="${INSTALLDIR}/bin:${PATH}"
 ENV OPENSSL=${INSTALLDIR}/bin/openssl
 ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
 
-WORKDIR ${INSTALLDIR}/bin
-
-RUN set -x && mkdir /opt/test 
-
-COPY scripts/* /opt/test/
-# ToDo: Add further test scripts here
-
 WORKDIR ${INSTALLDIR}
 
 FROM dev
 ARG INSTALLDIR
 
 # Enable a normal user to create new server keys off set CA
-RUN addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test 
+RUN addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test
 
 # permit changes to liboqs lib by normal oqs user:
-RUN chmod gou+rwx /opt/oqssa/lib
-RUN chmod gou+rwx /opt/oqssa/lib/*
-#USER oqs
+RUN chmod gou+rwx /opt/oqssa/lib && chmod gou+rwx /opt/oqssa/lib/*
+
+USER oqs
 WORKDIR /opt/test
 CMD ["/opt/test/run-tests.sh"]
-#STOPSIGNAL SIGTERM
+STOPSIGNAL SIGTERM

--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -74,15 +74,15 @@ RUN mkdir build-static-noport-arm64 && cd build-static-noport-arm64 && cmake -DC
 
 # build OQS-OpenSSL 
 WORKDIR /opt/ossl-src-arm64
-RUN CC=aarch64-linux-gnu-gcc LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./Configure linux-aarch64 shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR}-arm64 && \
+RUN CC=aarch64-linux-gnu-gcc LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./Configure linux-aarch64 shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
     make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
 
 # set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
 
 # generate certificates for openssl s_server, which is what we will test curl against
-ENV OPENSSL=${INSTALLDIR}-arm64/bin/openssl
-ENV OPENSSL_CNF=${INSTALLDIR}-arm64/ssl/openssl.cnf
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
 
 WORKDIR ${INSTALLDIR}/bin
 # generate CA key and cert
@@ -107,7 +107,7 @@ RUN apt-get update -qq && \
     apt autoremove && rm -rf /var/cache/apt/*
 
 # Retain the ${INSTALLDIR} contents in the final image
-COPY --from=intermediate ${INSTALLDIR}-arm64 ${INSTALLDIR}
+COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}
 # Also retain liboqs speed-executables
 COPY --from=intermediate /opt/liboqs/build-static-arm64/tests/speed_kem ${INSTALLDIR}/bin/speed_kem
 COPY --from=intermediate /opt/liboqs/build-static-arm64/tests/speed_sig ${INSTALLDIR}/bin/speed_sig

--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -81,8 +81,8 @@ RUN CC=aarch64-linux-gnu-gcc LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./Config
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
 
 # generate certificates for openssl s_server, which is what we will test curl against
-ENV OPENSSL=${INSTALLDIR}/bin/openssl
-ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+ENV OPENSSL=${INSTALLDIR}-arm64/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}-arm64/ssl/openssl.cnf
 
 WORKDIR ${INSTALLDIR}/bin
 # generate CA key and cert

--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -1,0 +1,132 @@
+# Multi-stage build: First the full builder image:
+
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
+
+# liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
+ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
+#ARG LIBOQS_BUILD_DEFINES=""
+
+# openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
+ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768:newhope1024cca"
+
+# Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
+ARG SIG_ALG="dilithium2"
+
+# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
+ARG MAKE_DEFINES="-j 2"
+
+# Define main performance architecture(s)
+ARG PERF_ARCH_ARM64="cortex-a72"
+
+# default architecture
+ARG ARCH="amd64"
+
+FROM multiarch/debian-debootstrap:${ARCH}-buster as intermediate
+# Take in all global args
+ARG INSTALLDIR
+ARG LIBOQS_BUILD_DEFINES
+ARG OPENSSL_BUILD_DEFINES
+ARG SIG_ALG
+ARG PERF_ARCH_ARM64
+ARG MAKE_DEFINES
+
+LABEL version="2"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Get all software packages required for builing all components:
+RUN dpkg --add-architecture arm64 && \
+    apt-get update -qq && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y gcc \
+       cmake ninja-build \
+       autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev \
+       doxygen  \
+       python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io \
+       python3-psutil \
+       maven openjdk-11-jdk \
+       gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu qemu-user-static \
+       docker \
+       libssl-dev:arm64 s3fs
+
+
+# get all sources
+WORKDIR /opt
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
+    git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src-arm64
+
+WORKDIR /opt/liboqs
+
+# cross build shared and static, distributable 
+RUN mkdir build-shared-arm64 && cd build-shared-arm64 && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src-arm64/oqs && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-arm64 && cd build-static-arm64 && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src-arm64/oqs && make ${MAKE_DEFINES} && make install
+
+# Build ref-only variants and store in INSTALLDIR-ref-arm64
+RUN mkdir build-shared-ref-arm64 && cd build-shared-ref-arm64 && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref-arm64 && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-ref-arm64 && cd build-static-ref-arm64 && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref-arm64 && make ${MAKE_DEFINES} && make install
+
+# Build noportable fast variants and store in INSTALLDIR-noport-arm64 (liboqs build default) 
+RUN mkdir build-shared-noport-arm64 && cd build-shared-noport-arm64 && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET=${PERF_ARCH_ARM64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport-arm64 && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-noport-arm64 && cd build-static-noport-arm64 && cmake -DCMAKE_TOOLCHAIN_FILE=../.CMake/toolchain_arm64.cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET=${PERF_ARCH_ARM64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport-arm64 && make ${MAKE_DEFINES} && make install
+
+# build OQS-OpenSSL 
+WORKDIR /opt/ossl-src-arm64
+# at ./configure time
+RUN CC=aarch64-linux-gnu-gcc LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./Configure linux-aarch64 shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR}-arm64 && \
+    make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
+
+WORKDIR /
+
+## second stage (ARM64): Only create minimal image without build tooling and intermediate build results generated above:
+# must be run on arm64 (emulated) host
+FROM arm64v8/debian:buster-slim 
+
+# Take in global args
+ARG INSTALLDIR
+
+# Dependencies for logfile analysis and S3FS:
+# Get all software packages required for builing all components:
+RUN apt-get update -qq && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y python3 fuse valgrind libssl-dev s3fs && \
+    apt autoremove && rm -rf /var/cache/apt/*
+
+RUN set -x && mkdir -p /opt/test && mkdir -p /opt/oqssa/lib && addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test && chmod -R gou+rwx /opt/oqssa/lib
+
+# Retain the ${INSTALLDIR} contents in the final image
+COPY --from=intermediate ${INSTALLDIR}-arm64 ${INSTALLDIR}
+# Also retain liboqs speed-executables
+COPY --from=intermediate /opt/liboqs/build-static-arm64/tests/speed_kem ${INSTALLDIR}/bin/speed_kem
+COPY --from=intermediate /opt/liboqs/build-static-arm64/tests/speed_sig ${INSTALLDIR}/bin/speed_sig
+COPY --from=intermediate /opt/liboqs/build-static-ref-arm64/tests/speed_kem ${INSTALLDIR}/bin/speed_kem-ref
+COPY --from=intermediate /opt/liboqs/build-static-ref-arm64/tests/speed_sig ${INSTALLDIR}/bin/speed_sig-ref
+COPY --from=intermediate /opt/liboqs/build-static-noport-arm64/tests/speed_kem ${INSTALLDIR}/bin/speed_kem-noport
+COPY --from=intermediate /opt/liboqs/build-static-noport-arm64/tests/speed_sig ${INSTALLDIR}/bin/speed_sig-noport
+# Also retain liboqs test_mem-executables
+COPY --from=intermediate /opt/liboqs/build-static-arm64/tests/test_kem_mem ${INSTALLDIR}/bin/test_kem_mem
+COPY --from=intermediate /opt/liboqs/build-static-arm64/tests/test_sig_mem ${INSTALLDIR}/bin/test_sig_mem
+COPY --from=intermediate /opt/liboqs/build-static-ref-arm64/tests/test_kem_mem ${INSTALLDIR}/bin/test_kem_mem-ref
+COPY --from=intermediate /opt/liboqs/build-static-ref-arm64/tests/test_sig_mem ${INSTALLDIR}/bin/test_sig_mem-ref
+COPY --from=intermediate /opt/liboqs/build-static-noport-arm64/tests/test_kem_mem ${INSTALLDIR}/bin/test_kem_mem-noport
+COPY --from=intermediate /opt/liboqs/build-static-noport-arm64/tests/test_sig_mem ${INSTALLDIR}/bin/test_sig_mem-noport
+
+COPY scripts/* /opt/test/
+
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# config locations
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+
+WORKDIR ${INSTALLDIR}/bin
+
+RUN chown -R oqs.oqs /opt/test && chmod gou+rwx /opt/oqssa/lib /opt/oqssa/lib/*
+
+#USER oqs
+WORKDIR /opt/test
+CMD ["/opt/test/run-tests.sh"]
+STOPSIGNAL SIGTERM

--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -4,8 +4,9 @@
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
-#ARG LIBOQS_BUILD_DEFINES=""
+# for minimal build
+#ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
+ARG LIBOQS_BUILD_DEFINES=""
 
 # openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
 ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768:newhope1024cca"

--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -74,15 +74,26 @@ RUN mkdir build-static-noport-arm64 && cd build-static-noport-arm64 && cmake -DC
 
 # build OQS-OpenSSL 
 WORKDIR /opt/ossl-src-arm64
-# at ./configure time
 RUN CC=aarch64-linux-gnu-gcc LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./Configure linux-aarch64 shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR}-arm64 && \
     make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
+
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# generate certificates for openssl s_server, which is what we will test curl against
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+
+WORKDIR ${INSTALLDIR}/bin
+# generate CA key and cert
+RUN set -x && \
+    ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF}
 
 WORKDIR /
 
 ## second stage (ARM64): Only create minimal image without build tooling and intermediate build results generated above:
 # must be run on arm64 (emulated) host
-FROM arm64v8/debian:buster-slim 
+FROM arm64v8/debian:buster-slim as dev
 
 # Take in global args
 ARG INSTALLDIR
@@ -94,8 +105,6 @@ RUN apt-get update -qq && \
     apt-get dist-upgrade -y && \
     apt-get install -y python3 fuse valgrind libssl-dev s3fs && \
     apt autoremove && rm -rf /var/cache/apt/*
-
-RUN set -x && mkdir -p /opt/test && mkdir -p /opt/oqssa/lib && addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test && chmod -R gou+rwx /opt/oqssa/lib
 
 # Retain the ${INSTALLDIR} contents in the final image
 COPY --from=intermediate ${INSTALLDIR}-arm64 ${INSTALLDIR}
@@ -123,11 +132,20 @@ ENV PATH="${INSTALLDIR}/bin:${PATH}"
 ENV OPENSSL=${INSTALLDIR}/bin/openssl
 ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
 
-WORKDIR ${INSTALLDIR}/bin
 
-RUN chown -R oqs.oqs /opt/test && chmod gou+rwx /opt/oqssa/lib /opt/oqssa/lib/*
 
-#USER oqs
+WORKDIR ${INSTALLDIR}
+
+FROM dev
+ARG INSTALLDIR
+
+# Enable a normal user to create new server keys off set CA
+RUN addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test
+
+# permit changes to liboqs lib by normal oqs user:
+RUN chmod gou+rwx /opt/oqssa/lib && chmod gou+rwx /opt/oqssa/lib/*
+
+USER oqs
 WORKDIR /opt/test
 CMD ["/opt/test/run-tests.sh"]
 STOPSIGNAL SIGTERM

--- a/perf/scripts/run-tests.sh
+++ b/perf/scripts/run-tests.sh
@@ -7,7 +7,7 @@ S3FOLDER=/tmp/s3dir
 ARCH=-`uname -m`
 
 echo "outputting some system information first"
-dmesg
+cat /etc/os-release
 hostname
 
 cd /opt/test

--- a/perf/scripts/run-tests.sh
+++ b/perf/scripts/run-tests.sh
@@ -8,6 +8,7 @@ ARCH=-`uname -m`
 
 echo "outputting some system information first"
 cat /etc/os-release
+uname -a
 hostname
 
 cd /opt/test

--- a/perf/scripts/run_mem.py
+++ b/perf/scripts/run_mem.py
@@ -44,6 +44,9 @@ fieldname=["insts", "maxBytes", "maxHeap", "extHeap", "maxStack"]
 def do_test(alg, meth, methnames, exepath):
    process = subprocess.Popen(["valgrind", "--tool=massif", "--stacks=yes", "--massif-out-file=valgrind-out", exepath, alg, str(meth)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,universal_newlines=True)
    (outs, errs) = process.communicate()
+   if process.returncode != 0:
+      print("Valgrind died with retcode %d and \n%s\n%s\nFatal error. Exiting." % (process.returncode, outs, errs))
+      exit(1)
    if len(data["config"]) == 0:
       parse_config(outs)
    process = subprocess.Popen(["ms_print", "valgrind-out"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,universal_newlines=True)
@@ -76,7 +79,7 @@ try:
 except FileExistsError:
    activealgs=[]
 
-# first determine all possible algorithm
+# first determine all enabled algorithms
 process = subprocess.Popen([exepath], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,universal_newlines=True)
 (outs, errs) = process.communicate()
 for line in outs.splitlines():
@@ -99,7 +102,7 @@ for alg in algs:
 for alg in activealgs:
    data[alg]={}
    # Activate this for a quick test:
-   #if alg=="BIKE1-L3-FO" or alg=="DILITHIUM_3":
+   #if alg=="DEFAULT":
    for i in range(3):
       do_test(alg, i, methnames, exepath)
 


### PR DESCRIPTION
- Profiling switched to debian, incl. overall size reduction (curl eliminated)
- Cross-build for ARM64 as separate job added (more simple approach using `docker buildx` failed/timed out after 5h: >10000 compile tasks using qemu just is not workable)
- Integration to multiarch docker image (fixes #46) working around various docker arch tagging issues
- Bugfix in memory testing if not all algorithms enabled