### PR TITLE
add ARM64 cpuinfo

### DIFF
--- a/perf/scripts/parse_liboqs_speed.py
+++ b/perf/scripts/parse_liboqs_speed.py
@@ -11,7 +11,8 @@ class State(Enum):
    parsing=2
 
 data={}
-data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz"])
+# fetch both x86 and aarch64 CPU details:
+data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
 
 if len(sys.argv)!=2:
    print("Usage: %s <logfile to parse>" % (sys.argv[0]))

--- a/perf/scripts/parse_openssl_speed.py
+++ b/perf/scripts/parse_openssl_speed.py
@@ -28,7 +28,8 @@ if len(sys.argv)!=2:
 
 # Resultdata
 data={}
-data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz"])
+# fetch both x86 and aarch64 CPU details:
+data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
 
 fn = sys.argv[1]
 state = State.config

--- a/perf/scripts/run_mem.py
+++ b/perf/scripts/run_mem.py
@@ -6,7 +6,8 @@ import os
 from get_cpuinfo import getcpuinfo
 
 data = {}
-data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz"])
+# fetch both x86 and aarch64 CPU details:
+data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
 data["config"]={}
 
 def get_peak(lines):


### PR DESCRIPTION
Fixes #64

@christianpaquin @xvzcf @dstebila Please check whether the captured CPU information (from `/proc/cpuinfo`) in the changed files now seems sufficient to permit review of "surprising" future results.