### PR TITLE
Adding aarch64 cpu frequency estimates

### DIFF
--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -96,7 +96,7 @@ ARG SIG_ALG
 # Get all software packages required for builing all components:
 RUN apt update && apt upgrade -y && \
     apt dist-upgrade -y && \
-    apt install -y python3 fuse valgrind libssl-dev s3fs git && \
+    apt install -y python3 fuse valgrind libssl-dev s3fs git linux-perf && \
     apt autoremove && rm -rf /var/cache/apt/*
 
 # Retain the ${INSTALLDIR} contents in the final image

--- a/perf/scripts/get_cpuinfo.py
+++ b/perf/scripts/get_cpuinfo.py
@@ -1,4 +1,34 @@
 import subprocess
+from sys import platform
+
+def getestimatedcpufrequency():
+    if platform != "linux" and platform != "linux2":
+        return None
+
+    # estimating CPU frequency using perf
+    p = subprocess.Popen(["lscpu"], text=True, stdout=subprocess.PIPE)
+    maxfreq = None
+    minfreq = None
+    while True:
+        line = p.stdout.readline()
+        if not line: break
+        if "CPU max MHz" in line:
+            try:
+                maxfreq = line.split(":")[1].rstrip().lstrip()
+                unit = line.split(":")[0].split(" ")[2]
+                maxfreq = "{} {}".format(maxfreq, unit)
+            except:
+                pass
+        if "CPU min MHz" in line:
+            try:
+                minfreq = line.split(":")[1].rstrip().lstrip()
+                unit = line.split(":")[0].split(" ")[2]
+                minfreq = "{} {}".format(minfreq, unit)
+            except:
+                pass
+
+    return minfreq, maxfreq
+
 
 def getcpuinfo(required_tags):
   tags = {}
@@ -18,9 +48,9 @@ def getcpuinfo(required_tags):
 
   for line in lines:
     if ":" in line:
-       (t,v)=line.split(":",1)
-       t=t.rstrip().lstrip()
-       v=v.rstrip().lstrip()
+       (t,v) = line.split(":",1)
+       t = t.rstrip().lstrip()
+       v = v.rstrip().lstrip()
        if (t in required_tags) and (not t in tags.keys()):
-          tags[t]=v 
+          tags[t] = v 
   return tags

--- a/perf/scripts/get_cpuinfo.py
+++ b/perf/scripts/get_cpuinfo.py
@@ -1,34 +1,21 @@
 import subprocess
-from sys import platform
-
+import platform
+from shutil import which
 def getestimatedcpufrequency():
-    if platform != "linux" and platform != "linux2":
+    if platform.system() != "Linux" or platform.processor() != "aarch64":
         return None
+    
+    if which("perf"):
+        p = subprocess.Popen(["perf", "stat", "sleep", "1"], text=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        lines = p.communicate()[1]
+        frequency = None
+        for line in lines.splitlines():
+            if "cycles" in line:
+                l = line.split("#")[1]
+                l = l.rstrip().lstrip()
+                return l
 
-    # estimating CPU frequency using perf
-    p = subprocess.Popen(["lscpu"], text=True, stdout=subprocess.PIPE)
-    maxfreq = None
-    minfreq = None
-    while True:
-        line = p.stdout.readline()
-        if not line: break
-        if "CPU max MHz" in line:
-            try:
-                maxfreq = line.split(":")[1].rstrip().lstrip()
-                unit = line.split(":")[0].split(" ")[2]
-                maxfreq = "{} {}".format(maxfreq, unit)
-            except:
-                pass
-        if "CPU min MHz" in line:
-            try:
-                minfreq = line.split(":")[1].rstrip().lstrip()
-                unit = line.split(":")[0].split(" ")[2]
-                minfreq = "{} {}".format(minfreq, unit)
-            except:
-                pass
-
-    return minfreq, maxfreq
-
+    return None
 
 def getcpuinfo(required_tags):
   tags = {}

--- a/perf/scripts/parse_liboqs_speed.py
+++ b/perf/scripts/parse_liboqs_speed.py
@@ -4,6 +4,7 @@ import os
 import re
 from enum import Enum
 from get_cpuinfo import getcpuinfo
+from get_cpuinfo import getestimatedcpufrequency
 
 class State(Enum):
    starting=0
@@ -13,6 +14,15 @@ class State(Enum):
 data={}
 # fetch both x86 and aarch64 CPU details:
 data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
+minfreq, maxfreq = getestimatedcpufrequency()
+if minfreq != None:
+    data["cpuinfo"]["estminfrequency"] = minfreq
+else:
+    data["cpuinfo"]["estminfreqency"] = "Unavailable"
+if maxfreq != None:
+    data["cpuinfo"]["estmaxfrequency"] = maxfreq
+else:
+    data["cpuinfo"]["estmaxfreqency"] = "Unavailable"
 
 if len(sys.argv)!=2:
    print("Usage: %s <logfile to parse>" % (sys.argv[0]))

--- a/perf/scripts/parse_liboqs_speed.py
+++ b/perf/scripts/parse_liboqs_speed.py
@@ -14,15 +14,11 @@ class State(Enum):
 data={}
 # fetch both x86 and aarch64 CPU details:
 data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
-minfreq, maxfreq = getestimatedcpufrequency()
-if minfreq != None:
-    data["cpuinfo"]["estminfrequency"] = minfreq
+estfrequency = getestimatedcpufrequency()
+if estfrequency != None:
+    data["cpuinfo"]["estfrequency"] = estfrequency
 else:
-    data["cpuinfo"]["estminfreqency"] = "Unavailable"
-if maxfreq != None:
-    data["cpuinfo"]["estmaxfrequency"] = maxfreq
-else:
-    data["cpuinfo"]["estmaxfreqency"] = "Unavailable"
+    data["cpuinfo"]["estfrequency"] = "Unavailable"
 
 if len(sys.argv)!=2:
    print("Usage: %s <logfile to parse>" % (sys.argv[0]))

--- a/perf/scripts/parse_openssl_speed.py
+++ b/perf/scripts/parse_openssl_speed.py
@@ -4,6 +4,7 @@ import os
 import re
 from enum import Enum
 from get_cpuinfo import getcpuinfo
+from get_cpuinfo import getestimatedcpufrequency
 
 # get operations per sec tags in a line containing <tagname>/s 
 def gettags(line):
@@ -30,6 +31,15 @@ if len(sys.argv)!=2:
 data={}
 # fetch both x86 and aarch64 CPU details:
 data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
+minfreq, maxfreq = getestimatedcpufrequency()
+if minfreq != None:
+    data["cpuinfo"]["estminfrequency"] = minfreq
+else:
+    data["cpuinfo"]["estminfreqency"] = "Unavailable"
+if maxfreq != None:
+    data["cpuinfo"]["estmaxfrequency"] = maxfreq
+else:
+    data["cpuinfo"]["estmaxfreqency"] = "Unavailable"
 
 fn = sys.argv[1]
 state = State.config

--- a/perf/scripts/parse_openssl_speed.py
+++ b/perf/scripts/parse_openssl_speed.py
@@ -31,15 +31,11 @@ if len(sys.argv)!=2:
 data={}
 # fetch both x86 and aarch64 CPU details:
 data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
-minfreq, maxfreq = getestimatedcpufrequency()
-if minfreq != None:
-    data["cpuinfo"]["estminfrequency"] = minfreq
+estfrequency = getestimatedcpufrequency()
+if estfrequency != None:
+    data["cpuinfo"]["estfrequency"] = estfrequency
 else:
-    data["cpuinfo"]["estminfreqency"] = "Unavailable"
-if maxfreq != None:
-    data["cpuinfo"]["estmaxfrequency"] = maxfreq
-else:
-    data["cpuinfo"]["estmaxfreqency"] = "Unavailable"
+    data["cpuinfo"]["estfreqency"] = "Unavailable"
 
 fn = sys.argv[1]
 state = State.config

--- a/perf/scripts/run_mem.py
+++ b/perf/scripts/run_mem.py
@@ -9,15 +9,11 @@ data = {}
 # fetch both x86 and aarch64 CPU details:
 data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
 data["config"]={}
-minfreq, maxfreq = getestimatedcpufrequency()
-if minfreq != None:
-    data["cpuinfo"]["estminfrequency"] = minfreq
+estfreqency = getestimatedcpufrequency()
+if estfrequency != None:
+    data["cpuinfo"]["estfrequency"] = estfrequency
 else:
-    data["cpuinfo"]["estminfreqency"] = "Unavailable"
-if maxfreq != None:
-    data["cpuinfo"]["estmaxfrequency"] = maxfreq
-else:
-    data["cpuinfo"]["estmaxfreqency"] = "Unavailable"
+    data["cpuinfo"]["estfreqency"] = "Unavailable"
 
 def get_peak(lines):
     peak = -1

--- a/perf/scripts/run_mem.py
+++ b/perf/scripts/run_mem.py
@@ -4,11 +4,20 @@ import subprocess
 import sys
 import os
 from get_cpuinfo import getcpuinfo
-
+from get_cpuinfo import getestimatedcpufrequency
 data = {}
 # fetch both x86 and aarch64 CPU details:
 data["cpuinfo"]=getcpuinfo(["flags", "model name", "cpu MHz", "Features", "CPU implementer", "CPU variant", "CPU part", "BogoMIPS"])
 data["config"]={}
+minfreq, maxfreq = getestimatedcpufrequency()
+if minfreq != None:
+    data["cpuinfo"]["estminfrequency"] = minfreq
+else:
+    data["cpuinfo"]["estminfreqency"] = "Unavailable"
+if maxfreq != None:
+    data["cpuinfo"]["estmaxfrequency"] = maxfreq
+else:
+    data["cpuinfo"]["estmaxfreqency"] = "Unavailable"
 
 def get_peak(lines):
     peak = -1


### PR DESCRIPTION
Some aarch64 CPUs don't report their frequency in `/proc/cpuinfo`. This PR uses perf to estimate the current cpu clock sleep and adds it to the various json files generated.