### PR TITLE
hybrid KEM handshaking added

### DIFF
--- a/perf/Dockerfile
+++ b/perf/Dockerfile
@@ -60,8 +60,8 @@ RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD
 RUN mkdir build-static && cd build-static && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 
 # Build ref-only variants and store in INSTALLDIR-ref (x86_64)
-RUN mkdir build-shared-ref && cd build-shared-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
-RUN mkdir build-static-ref && cd build-static-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
+RUN mkdir build-shared-ref && cd build-shared-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=OFF -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static-ref && cd build-static-ref && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=OFF -DBUILD_SHARED_LIBS=OFF -DOQS_OPT_TARGET="generic" -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-ref && make ${MAKE_DEFINES} && make install
 
 # Build noportable fast variants and store in INSTALLDIR-noport (liboqs build default) (x86_64)
 RUN mkdir build-shared-noport && cd build-shared-noport && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DOQS_OPT_TARGET=${PERF_ARCH_X64} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/oqs-noport && make ${MAKE_DEFINES} && make install

--- a/perf/scripts/handshakes.py
+++ b/perf/scripts/handshakes.py
@@ -46,9 +46,17 @@ def populate_algs():
    return kems,sigs
 
 kems,sigs=populate_algs()
+print("Baseline KEMs:")
+print(kems)
+print("Baseline SIGs:")
+print(sigs)
 # Limit testing as per https://github.com/open-quantum-safe/profiling/issues/83#issuecomment-1345546025
 kems = ['kyber512', 'kyber768', 'kyber1024', 'p256_kyber512', 'p384_kyber768', 'p521_kyber1024', 'secp256k1', 'secp384r1', 'X25519', 'X448']
-sigs = ['dilithium2', 'p256_dilithium2', 'rsa3072_dilithium2', 'dilithium3', 'p384_dilithium3', 'dilithium5', 'p521_dilithium5', 'falcon512', 'p256_falcon512', 'rsa3072_falcon512', 'falcon1024', 'p521_falcon1024', 'ED448', 'ED25519', 'RSA:2048', 'RSA:3072', 'ECDSAprime256v1', 'ECDSAsecp384r1']
+sigs = ['dilithium2', 'p256_dilithium2', 'rsa3072_dilithium2', 'dilithium3', 'p384_dilithium3', 'dilithium5', 'p521_dilithium5', 'falcon512', 'p256_falcon512', 'rsa3072_falcon512', 'falcon1024', 'p521_falcon1024', 'sphincsharaka128fsimple', 'p256_sphincsharaka128fsimple', 'rsa3072_sphincsharaka128fsimple', 'sphincssha256128ssimple', 'p256_sphincssha256128ssimple', 'rsa3072_sphincssha256128ssimple', 'sphincsshake256128fsimple', 'p256_sphincsshake256128fsimple', 'rsa3072_sphincsshake256128fsimple', 'ED448', 'ED25519', 'RSA:2048', 'RSA:3072', 'ECDSAprime256v1', 'ECDSAsecp384r1']
+print("KEMs under test:")
+print(kems)
+print("SIGs under test:")
+print(sigs)
 
 if len(sys.argv)>1:
    # pass in installdir

--- a/perf/scripts/handshakes.py
+++ b/perf/scripts/handshakes.py
@@ -46,6 +46,9 @@ def populate_algs():
    return kems,sigs
 
 kems,sigs=populate_algs()
+# Limit testing as per https://github.com/open-quantum-safe/profiling/issues/83#issuecomment-1345546025
+kems = ['kyber512', 'kyber768', 'kyber1024', 'p256_kyber512', 'p384_kyber768', 'p521_kyber1024', 'secp256k1', 'secp384r1', 'X25519', 'X448']
+sigs = ['dilithium2', 'p256_dilithium2', 'rsa3072_dilithium2', 'dilithium3', 'p384_dilithium3', 'dilithium5', 'p521_dilithium5', 'falcon512', 'p256_falcon512', 'rsa3072_falcon512', 'falcon1024', 'p521_falcon1024', 'ED448', 'ED25519', 'RSA:2048', 'RSA:3072', 'ECDSAprime256v1', 'ECDSAsecp384r1']
 
 if len(sys.argv)>1:
    # pass in installdir


### PR DESCRIPTION
Fixes #83 
Fixes #87

HOWEVER, please note that I did as discussed in https://github.com/open-quantum-safe/profiling/issues/83#issuecomment-1345546025. ~The consequence of which is that all Sphincs+ tests are gone because oqs-openssl111 only activates "robust" variants~.

So before declaring this Ready for Review, @christianpaquin here's the question: Do we want to (also/alternatively) enable "simple" Sphincs+ variants in oqs-openssl111 instead? Upstream or only in profiling? Or shall we keep the "robust" variants as before (knowing they won't be standardized)?

Edit/Add: Option 1 (changing sphincs+ std algs) implemented in https://github.com/open-quantum-safe/openssl/pull/425. If that is merged, I'll complete this PR suitably.