### PR TITLE
adapt to changed results naming

### DIFF
--- a/perf/scripts/combine.py
+++ b/perf/scripts/combine.py
@@ -82,7 +82,18 @@ def merge(basepath, outpath, date, allarchs=False):
                       for a in archs:
                          data[k][a]={}
                  try:
-                   data[k][arch][ttype]=d[k]
+                   # hack required as openssl output naming changed: keygens/s->keygen/s, encaps/s->encap/s, decaps/s->decap/s
+                   nd = {}
+                   for dk in d[k].keys():
+                       if dk == "encaps/s":
+                          nd["encap/s"]=d[k][dk]
+                       elif dk == "decaps/s":
+                          nd["decap/s"]=d[k][dk]
+                       elif dk == "keygens/s":
+                          nd["keygen/s"]=d[k][dk]
+                       else:
+                          nd[dk] = d[k][dk]
+                   data[k][arch][ttype]=nd
                  except KeyError as ke:
                    print("key error at %s %s %s %s (%s)" %(k,arch,ttype,date))
     output_json(data, date, outpath, test)

--- a/perf/scripts/parse_openssl_speed.py
+++ b/perf/scripts/parse_openssl_speed.py
@@ -73,7 +73,8 @@ with open(fn) as fp:
                # Alg name is everything from start of line until start of first decimal number
                di = line.index(".")
                alg = line[:line.rfind(" ",0,di)].rstrip().lstrip().replace(":","")
-               data[alg]={}
+               # permit the same algorithm to be used in multiple categories:
+               if not alg in data: data[alg]={}
                for ti in range(len(tags)):
                    # go backwards:
                    f=line.rfind(" ",0,len(line)-2) 

--- a/perf/scripts/run-tests-m1.sh
+++ b/perf/scripts/run-tests-m1.sh
@@ -32,10 +32,14 @@ python3 handshakes.py /opt/oqssa 1
 
 cp results/speed_kem.json results/speed_kem-noport.json
 cp results/speed_sig.json results/speed_sig-noport.json
+cp results/mem_kem.json results/mem_kem-noport.json
+cp results/mem_sig.json results/mem_sig-noport.json
 cp results/speed.json results/speed-noport.json
 cp results/handshakes.json results/handshakes-noport.json
 cp results/speed_kem.json results/speed_kem-ref.json
 cp results/speed_sig.json results/speed_sig-ref.json
+cp results/mem_kem.json results/mem_kem-ref.json
+cp results/mem_sig.json results/mem_sig-ref.json
 cp results/speed.json results/speed-ref.json
 cp results/handshakes.json results/handshakes-ref.json
 


### PR DESCRIPTION
Fixes #94 

Also permits rsaXXX results to display as KEM _and_ SIG results and completes M1 mem visualization data (for -ref and -noport tests not run).