### PR TITLE
Bring M1 Dockerfile up to date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,38 @@ jobs:
                   docker tag oqs-mperf-arm64 $TARGETNAME/oqs-perf:latest-arm64 &&
                   docker push $TARGETNAME/oqs-perf:latest-arm64
 
+  debian_m1:
+    description: Build M1 benchmarking image on arm machine
+    machine:
+      image: 'ubuntu-2004:202101-01'
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Login to Docker Hub
+          command: |
+            echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+      - run:
+          name: Build docker image and test
+          command: |
+            uname -a
+            pwd
+            ls -l
+            docker build -t oqs-mperf-m1 -f Dockerfile-m1 .
+            docker run -it oqs-mperf-m1 /opt/test/selftest.sh
+          working_directory: perf
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
+          steps:
+            - run:
+                name: Push image
+                command: |
+                  docker tag oqs-mperf-m1 $TARGETNAME/oqs-perf:latest-m1 &&
+                  docker push $TARGETNAME/oqs-perf:latest-m1
+
   debian_x64:
     description: A template for building and pushing OQS performance testing Docker image on Ubuntu Bionic that depend on OQS-OpenSSL
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,8 +147,11 @@ workflows:
           context: openquantumsafe
       - debian_arm64:
           context: openquantumsafe
+      - debian_m1:
+          context: openquantumsafe
       - merge:
           requires:
              - debian_x64
              - debian_arm64
+             - debian_m1 # not doing anything with the M1 image in this job, but waiting out of caution
           context: openquantumsafe

--- a/perf/Dockerfile
+++ b/perf/Dockerfile
@@ -51,7 +51,7 @@ RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboq
 
 # Build OpenSSL3; set softlink to lib dir for cmake FindPackage
 WORKDIR /opt/ossl-src
-RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib64" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib64" ./config shared --prefix=${INSTALLDIR} && \
     make ${MAKE_DEFINES} && make install_sw && make install_ssldirs && ln -s ${INSTALLDIR}/lib64 ${INSTALLDIR}/lib;
 
 # build liboqs shared and static, distributable (x86_64)

--- a/perf/Dockerfile-arm64
+++ b/perf/Dockerfile-arm64
@@ -51,7 +51,7 @@ RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboq
 
 # Build OpenSSL3; set softlink to lib dir for cmake FindPackage
 WORKDIR /opt/ossl-src
-RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTALLDIR} && \
     make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
 
 # build liboqs shared and static, distributable (x86_64)

--- a/perf/Dockerfile-m1
+++ b/perf/Dockerfile-m1
@@ -8,9 +8,6 @@ ARG INSTALLDIR=/opt/oqssa
 #ARG LIBOQS_BUILD_DEFINES="-DOQS_MINIMAL_BUILD=ON"
 ARG LIBOQS_BUILD_DEFINES=""
 
-# openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
-ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768:newhope1024cca"
-
 # Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
 ARG SIG_ALG="dilithium2"
 
@@ -32,31 +29,39 @@ ENV DEBIAN_FRONTEND noninteractive
 # Get all software packages required for builing all components:
 RUN apt-get update -qq && \
     apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
     apt-get install -y gcc \
-       cmake \
-       autoconf automake git libssl-dev libtool make unzip wget zlib1g-dev \
-       doxygen ninja-build  \
-       python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist \
+       cmake ninja-build \
+       autoconf automake git libtool make unzip wget zlib1g-dev \
+       doxygen \
+       python3 python3-nose python3-rednose python3-pytest python3-pytest-xdist docker.io \
        python3-psutil \
        maven openjdk-11-jdk \
-       libssl-dev 
-
+       docker \
+       s3fs
 
 # get all sources
 WORKDIR /opt
 RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
-    git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src
+    git clone --depth 1 --branch master https://github.com/openssl/openssl.git ossl-src && \
+    git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
+
+# Build OpenSSL3; set softlink to lib dir for cmake FindPackage
+WORKDIR /opt/ossl-src
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTALLDIR} && \
+    make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
 
 # build liboqs shared and static, distributable
 WORKDIR /opt/liboqs
 # base platform build 
-RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
-RUN mkdir build-static && cd build-static && cmake .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
+RUN mkdir build && cd build && cmake -GNinja .. ${LIBOQS_BUILD_DEFINES} -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja && ninja install
+RUN mkdir build-static && cd build-static && cmake -GNinja -DOPENSSL_ROOT_DIR=${INSTALLDIR} .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja && ninja install
 
-# build OQS-OpenSSL
-WORKDIR /opt/ossl-src
-RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
-    make ${MAKE_DEFINES} && make install_sw && make install_ssldirs;
+# Build oqs-provider distributable
+WORKDIR /opt/oqs-provider
+RUN ln -s ../ossl-src openssl && cmake -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${INSTALLDIR} -S . -B _build && cmake --build _build  && cp _build/lib/oqsprovider.so ${INSTALLDIR}/lib/ossl-modules/oqsprovider-plain.so && sed -i "s/default = default_sect/default = default_sect\noqsprovider = oqsprovider_sect/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/\[default_sect\]/\[default_sect\]\nactivate = 1\n\[oqsprovider_sect\]\nactivate = 1\n/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/providers = provider_sect/providers = provider_sect\nssl_conf = ssl_sect\n\n\[ssl_sect\]\nsystem_default = system_default_sect\n\n\[system_default_sect\]\nGroups = \$ENV\:\:DEFAULT_GROUPS\n/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/HOME\t\t\t= ./HOME           = .\nDEFAULT_GROUPS = kyber512/g" /opt/oqssa/ssl/openssl.cnf
+
+# for now, don't bother with ref and fast variants
 
 # set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
@@ -64,6 +69,9 @@ ENV PATH="${INSTALLDIR}/bin:${PATH}"
 # generate certificates for openssl s_server, which is what we will test curl against
 ENV OPENSSL=${INSTALLDIR}/bin/openssl
 ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+
+# Activate one provider to allow the next commands to run:
+RUN cp ${INSTALLDIR}/lib/ossl-modules/oqsprovider-plain.so ${INSTALLDIR}/lib/ossl-modules/oqsprovider.so
 
 WORKDIR ${INSTALLDIR}/bin
 # generate CA key and cert
@@ -112,7 +120,7 @@ ARG INSTALLDIR
 RUN addgroup --gid 1000 oqs && adduser --system --disabled-password --gid 1000 --uid 1000 oqs && chown -R oqs.oqs /opt/test
 
 # permit changes to liboqs lib by normal oqs user:
-RUN chmod gou+rwx /opt/oqssa/lib && chmod gou+rwx /opt/oqssa/lib/*
+RUN chmod gou+rwx /opt/oqssa/lib && chmod gou+rwx /opt/oqssa/lib/* && chmod gou+rwx /opt/oqssa/lib/ossl-modules && chmod gou+rwx /opt/oqssa/lib/ossl-modules/*
 
 USER oqs
 WORKDIR /opt/test

--- a/perf/Dockerfile-m1
+++ b/perf/Dockerfile-m1
@@ -54,8 +54,8 @@ RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTAL
 # build liboqs shared and static, distributable
 WORKDIR /opt/liboqs
 # base platform build 
-RUN mkdir build && cd build && cmake -GNinja .. ${LIBOQS_BUILD_DEFINES} -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja && ninja install
-RUN mkdir build-static && cd build-static && cmake -GNinja -DOPENSSL_ROOT_DIR=${INSTALLDIR} .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja && ninja install
+RUN mkdir build && cd build && cmake -GNinja .. ${LIBOQS_BUILD_DEFINES} -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DOQS_DIST_BUILD=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja && ninja install
+RUN mkdir build-static && cd build-static && cmake -GNinja -DOPENSSL_ROOT_DIR=${INSTALLDIR} .. ${LIBOQS_BUILD_DEFINES} -DOQS_DIST_BUILD=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja && ninja install
 
 # Build oqs-provider distributable
 WORKDIR /opt/oqs-provider

--- a/perf/scripts/run-tests-m1.sh
+++ b/perf/scripts/run-tests-m1.sh
@@ -50,8 +50,8 @@ echo "Trying to mount S3..."
 if [ $? -eq 0 ]; then
     echo "Copy test results to S3"
     today=`date +%Y-%m-%d-%H_%M_%S`
-    tar czvf ${S3FOLDER}/${today}${ARCH}.tgz results/*.json
-    ./gen_website.sh ${S3FOLDER} ${ARCH}
+    tar czvf ${S3FOLDER}/m1compare${today}${ARCH}local.tgz results/*.json
+    #./gen_website.sh ${S3FOLDER} ${ARCH}
     echo "Copy complete: ${S3FOLDER}/${today}${ARCH}.tgz"
 else
     echo "Couldn't mount S3 bucket. Not copying out test results."

--- a/perf/scripts/run-tests.sh
+++ b/perf/scripts/run-tests.sh
@@ -76,8 +76,8 @@ echo "Trying to mount S3..."
 if [ $? -eq 0 ]; then
     echo "Copy test results to S3"
     today=`date +%Y-%m-%d-%H_%M_%S`
-    tar czvf ${S3FOLDER}/${today}${ARCH}.tgz results/*.json
-    ./gen_website.sh ${S3FOLDER} ${ARCH}
+    tar czvf ${S3FOLDER}/m1compare${today}${ARCH}ci.tgz results/*.json
+    #./gen_website.sh ${S3FOLDER} ${ARCH}
     echo "Copy complete: ${S3FOLDER}/${today}${ARCH}.tgz"
 else
     echo "Couldn't mount S3 bucket. Not copying out test results."


### PR DESCRIPTION
As per https://github.com/open-quantum-safe/profiling/pull/104#discussion_r1268120976 and #103, we would like to run tests on our M1 machine using both the dedicated M1 Dockerfile and the ARM64 Dockerfile to determine whether it's worth keeping the former around. This PR brings `Dockerfile-m1` in sync with `Dockerfile` and `Dockerfile-arm64` and updates the CircleCI config to build and push an `oqs-perf:latest-m1` image. The bulk of the changes involve updating the M1 Dockerfile to pull `open-quantum-safe/oqs-provider` instead of `open-quantum-safe/openssl`.

Two small items of note:
- I preemptively fixed the permissions issue fixed by #104 in the M1 Dockerfile. When that PR is merged, it will bring the three files in sync.
- I deleted the undefined `OPENSSL_BUILD_DEFINES` variable from OpenSSL build instructions in the ARM and x86 Dockerfiles.

This is the first step to resolving #103: once this PR and #104 are merged, I'll run some tests on the M1 machine and determine whether or not it's worth keeping the extra Dockerfile around. I suspect not, as it really is essentially the same as the ARM Dockerfile, but we'll see.